### PR TITLE
fix:  🐛 mainnet amends

### DIFF
--- a/examples/insert/package-set.dhall
+++ b/examples/insert/package-set.dhall
@@ -4,7 +4,7 @@ let Package =
 
 let
   additions =
-      [{ name = "cap-motoko-library"
+      [{ name = "cap"
       , repo = "https://github.com/Psychedelic/cap-motoko-library"
       , version = "v1.0.1"
       , dependencies = [] : List Text

--- a/examples/insert/src/main.mo
+++ b/examples/insert/src/main.mo
@@ -26,7 +26,7 @@ actor InsertExample {
     // The number of cycles to use when initialising
     // the handshake process which creates a new canister
     // and install the bucket code into cap service
-    let creationCycles : Nat = 100_000_000_000;
+    let creationCycles : Nat = 1_000_000_000_000;
 
     public func id() : async Principal {
         return Principal.fromActor(InsertExample);

--- a/examples/insert/src/main.mo
+++ b/examples/insert/src/main.mo
@@ -1,8 +1,8 @@
 import Principal "mo:base/Principal";
-import CapMotokoLibrary "mo:cap-motoko-library/Cap";
-import Root "mo:cap-motoko-library/Root";
+import Cap "mo:cap/Cap";
+import Root "mo:cap/Root";
 import Result "mo:base/Result";
-import Types "mo:cap-motoko-library/Types";
+import Types "mo:cap/Types";
 import Debug "mo:base/Debug";
 
 actor InsertExample {
@@ -16,17 +16,17 @@ actor InsertExample {
     // the Cap repo is located at https://github.com/Psychedelic/cap
     // see the releases https://github.com/Psychedelic/cap/tags
     // to ensure you get a working version
-    let local_replica_router_id = "rrkah-fqaaa-aaaaa-aaaaq-cai";
+    let localReplicaRouterId = "rrkah-fqaaa-aaaaa-aaaaq-cai";
 
     // If the local replica router is not set
     // then the mainnet id is used "lj532-6iaaa-aaaah-qcc7a-cai" 
     // and because the expected argument is an optional we pass as ?xxx
-    let cap = CapMotokoLibrary.Cap(?local_replica_router_id);
+    let cap = Cap.Cap(?localReplicaRouterId);
 
     // The number of cycles to use when initialising
     // the handshake process which creates a new canister
     // and install the bucket code into cap service
-    let creation_cycles : Nat = 100000000000;
+    let creationCycles : Nat = 100_000_000_000;
 
     public func id() : async Principal {
         return Principal.fromActor(InsertExample);
@@ -38,15 +38,15 @@ actor InsertExample {
         // in the cap-motoko-library/examples directory
         // after you have deployed the cap-motoko-example
         let pid = await id();
-        let token_contract_id = Principal.toText(pid);
+        let tokenContractId = Principal.toText(pid);
 
         // As a demo, the parameters are hard-typed here
         // but could be declared in the function signature
         // and pass when executing the request
         let handshake = await cap.handshake(
-          local_replica_router_id,
-          token_contract_id,
-          creation_cycles
+          localReplicaRouterId,
+          tokenContractId,
+          creationCycles
         );
     };
 

--- a/examples/insert/vessel.dhall
+++ b/examples/insert/vessel.dhall
@@ -1,4 +1,4 @@
 {
-  dependencies = [ "base", "matchers", "cap-motoko-library" ],
+  dependencies = [ "base", "matchers", "cap" ],
   compiler = None Text
 }

--- a/src/Cap.mo
+++ b/src/Cap.mo
@@ -37,9 +37,8 @@ import Types "Types";
 module {
     public class Cap(
         overrideRouterId    : ?Text,
-        overrideRootBucketId: ?Text,
     ) {
-        var rootBucket: ?Text = overrideRootBucketId;
+        var rootBucket: ?Text = null;
 
         let routerId = Option.get(overrideRouterId, Router.mainnet_id);
         let ic: IC.ICActor = actor("aaaaa-aa");

--- a/src/Cap.mo
+++ b/src/Cap.mo
@@ -3,9 +3,9 @@
 /// Minimal working example:
 ///
 /// ```motoko
-/// import Cap "mo:cap-motoko-library/Cap";
+/// import Cap "mo:cap/Cap";
 ///
-/// let cap = CapMotokoLibrary.Cap(?local_replica_routerId);
+/// let cap = CapMotokoLibrary.Cap(?localReplicaRouterId);
 /// let tokenContractId = "rdmx6-jaaaa-aaaaa-aaadq-cai";
 ///
 /// public func init() : async () {
@@ -13,7 +13,7 @@
 ///     // but could be declared in the function signature
 ///     // and pass when executing the request
 ///     let handshake = await cap.handshake(
-///       local_replica_routerId,
+///       localReplicaRouterId,
 ///       tokenContractId,
 ///       creationCycles
 ///     );

--- a/src/Cap.mo
+++ b/src/Cap.mo
@@ -155,17 +155,6 @@ module {
                     switch (canister) {
                         case (?c) {
                             try {
-                                // NOTE: This call is failing on mainnet, but works locally.
-                                // DETAILS: IC0502: Canister lj532-6iaaa-aaaah-qcc7a-cai trapped: unreachable
-                                // This method in the CAP rust code has these panic cases:
-                                // - A root bucket for this token contract already exists.
-                                //   (Note that token contract principal is extracted from caller.)
-                                // - There is more than one controller on the canister.
-                                // - The canister is not empty, i.e. has any wasm installed.
-                                // The rust method also has the following exception cases:
-                                // - Canister status cannot be retrieved.
-                                // - Could not serialize the install arguments.
-                                // - Installing the code fails for some other reason.
                                 await router.install_bucket_code(c);
                             } catch e {
                                 throw Error.reject("Error installing code: " # Error.message(e));

--- a/src/Cap.mo
+++ b/src/Cap.mo
@@ -5,130 +5,189 @@
 /// ```motoko
 /// import Cap "mo:cap-motoko-library/Cap";
 ///
-/// let cap = CapMotokoLibrary.Cap(?local_replica_router_id);
-/// let token_contract_id = "rdmx6-jaaaa-aaaaa-aaadq-cai";
+/// let cap = CapMotokoLibrary.Cap(?local_replica_routerId);
+/// let tokenContractId = "rdmx6-jaaaa-aaaaa-aaadq-cai";
 ///
 /// public func init() : async () {
 ///     // As a demo, the parameters are hard-typed here
 ///     // but could be declared in the function signature
 ///     // and pass when executing the request
 ///     let handshake = await cap.handshake(
-///       local_replica_router_id,
-///       token_contract_id,
-///       creation_cycles
+///       local_replica_routerId,
+///       tokenContractId,
+///       creationCycles
 ///     );
 /// };
 /// ```
 
-import Result "mo:base/Result";
-import Principal "mo:base/Principal";
-import Debug "mo:base/Debug";
 import Cycles "mo:base/ExperimentalCycles";
-import Root "Root";
-import Types "Types";
-import Router "Router";
-import IC "IC";
+import Debug "mo:base/Debug";
+import Error "mo:base/Error";
+import Nat64 "mo:base/Nat64";
 import Option "mo:base/Option";
 import Prelude "mo:base/Prelude";
+import Principal "mo:base/Principal";
+import Result "mo:base/Result";
+
+import IC "IC";
+import Root "Root";
+import Router "Router";
+import Types "Types";
 
 module {
-    public class Cap(override_mainnet_router_id: ?Text, override_root_bucket_id: ?Text) {
-        let router_id = Option.get(override_mainnet_router_id, Router.mainnet_id);
-        
-        var rootBucket: ?Text = override_root_bucket_id;
-        let ic: IC.ICActor = actor("aaaaa-aa");
+    public class Cap(
+        overrideRouterId    : ?Text,
+        overrideRootBucketId: ?Text,
+    ) {
+        var rootBucket: ?Text = overrideRootBucketId;
 
-        public func getTransaction(id: Nat64) : async Result.Result<Root.Event, Types.GetTransactionError> {
+        let routerId = Option.get(overrideRouterId, Router.mainnet_id);
+        let ic: IC.ICActor = actor("aaaaa-aa");
+        let router: Router.Self = actor(routerId);
+
+        // Retrieves a transaction from the root bucket.
+        public func getTransaction(
+            id: Nat64,
+        ) : async Result.Result<Root.Event, Types.GetTransactionError> {
             let root = switch(rootBucket) {
-                case(?r) { r };
-                case(_) { Prelude.unreachable() };
+                case (?r) r;
+                case _ {
+                    throw Error.reject("Cannot call `getTransaction` with no root bucket.");
+                };
             };
             let rb: Root.Self = actor(root);
 
-            let transaction_response = await rb.get_transaction({ id=id; witness=false; });
-
-            switch(transaction_response) {
-                case (#Found(event, witness)) {
-                    switch(event) {
-                        case (null) {
-                            #err(#invalidTransaction)
-                        };
-                        case (?event) {
-                            #ok(event)
+            try {
+                switch(await rb.get_transaction({ id=id; witness=false; })) {
+                    case (#Found(event, witness)) {
+                        switch(event) {
+                            case (null) {
+                                #err(#invalidTransaction)
+                            };
+                            case (?event) {
+                                #ok(event)
+                            }
                         }
+                    };
+                    case (#Delegate(_, _)) {
+                        #err(#unsupportedResponse)
                     }
-                };
-                case (#Delegate(_, _)) {
-                    #err(#unsupportedResponse)
                 }
-            }
+            } catch e {
+                throw Error.reject(
+                    "Error getting transaction (" #
+                    Nat64.toText(id) # "): " #
+                    Error.message(e)
+                );
+            };
         };
 
-        public func insert(event: Root.IndefiniteEvent) : async Result.Result<Nat64, Types.InsertTransactionError> {
+        // Adds an event to the root bucket.
+        public func insert(
+            event: Root.IndefiniteEvent,
+        ) : async Result.Result<Nat64, Types.InsertTransactionError> {
             let root = switch(rootBucket) {
                 case(?r) { r };
                 case(_) {
-                    Debug.print("Trapping: Root bucket was undefined on call to `insert`.");
-                    Prelude.unreachable();
+                    throw Error.reject("Cannot call `insert` with no root bucket.");
                 };
             };
             let rb: Root.Self = actor(root);
 
-            let insert_response = await rb.insert(event);
-
-            // TODO: throw on error
-
-            #ok(insert_response)
+            try {
+                #ok(await rb.insert(event));
+            } catch e {
+                throw Error.reject("Error inserting event: " # Error.message(e));
+            };
         };
 
-        public func handshake(router_id : Text, token_contract_id : Text, creation_cycles: Nat): async () {
-            let router: Router.Self = actor(router_id);
+        // Attempts to retrieve an existing root bucket for a given token contract.
+        private func _getRootBucket (
+            tokenContractId : Text,
+        ) : async ?Text {
+            try {
+                let { canister } = await router.get_token_contract_root_bucket({
+                    canister = Principal.fromText(tokenContractId);
+                    witness  = false;
+                });
+                switch (canister) {
+                    case (?c) ?Principal.toText(c);
+                    case _ null;
+                };
+            } catch e {
+                throw Error.reject("Error querying router: " # Error.message(e));
+            };
+        };
 
-            let result = await router.get_token_contract_root_bucket({
-                witness=false;
-                canister=Principal.fromText(router_id);
-            });
-
-            switch(result.canister) {
-                case(null) {
+        // Get or create a root bucket canister for the given token contract.
+        public func handshake(
+            tokenContractId : Text,
+            creationCycles  : Nat,
+        ): async () {
+            switch(await _getRootBucket(tokenContractId)) {
+                case (?canister) {
+                    // If we already have a root bucket, store the principal in memory.
+                    rootBucket := ?canister;
+                };
+                case null {
+                    // We do not have a root bucket. Ask the router to make one.
                     let settings: IC.CanisterSettings = {
-                        controllers = ?[Principal.fromText(router_id)];
+                        controllers = ?[Principal.fromText(routerId)];
                         compute_allocation = null;
                         memory_allocation = null;
                         freezing_threshold = null;
                     };
-
                     let params: IC.CreateCanisterParams = {
                         settings = ?settings
                     };
+                    Cycles.add(creationCycles);
 
-                    // Add cycles and perform the create call
-                    Cycles.add(creation_cycles);
+                    // Ask the IC to create a canister.
+                    var canister : ?Principal = null;
+                    try {
+                        let { canister_id } = await ic.create_canister(params);
+                        canister := ?canister_id;
+                    } catch e {
+                        throw Error.reject("Error creating canister: " # Error.message(e));
+                    };
 
-                    let create_response = await ic.create_canister(params);
-
-                    // Install the cap code
-                    let canister = create_response.canister_id;
-
-                    await router.install_bucket_code(canister);
-
-                    // Find root by the token contract id
-                    let result = await router.get_token_contract_root_bucket({
-                        witness=false;
-                        canister=Principal.fromText(token_contract_id);
-                    });
-
-                    switch(result.canister) {
-                        case(null) {
-                            assert(false);
+                    // Ask the router to install root code into our new canister.
+                    switch (canister) {
+                        case (?c) {
+                            try {
+                                // NOTE: This call is failing on mainnet, but works locally.
+                                // DETAILS: IC0502: Canister lj532-6iaaa-aaaah-qcc7a-cai trapped: unreachable
+                                // This method in the CAP rust code has these panic cases:
+                                // - A root bucket for this token contract already exists.
+                                //   (Note that token contract principal is extracted from caller.)
+                                // - There is more than one controller on the canister.
+                                // - The canister is not empty, i.e. has any wasm installed.
+                                // The rust method also has the following exception cases:
+                                // - Canister status cannot be retrieved.
+                                // - Could not serialize the install arguments.
+                                // - Installing the code fails for some other reason.
+                                await router.install_bucket_code(c);
+                            } catch e {
+                                throw Error.reject("Error installing code: " # Error.message(e));
+                            };
                         };
-                        case(?canister) {
-                            rootBucket := ?Principal.toText(canister);
+                        case null {
+                            // Debug.print("Canister cannot be null after canister creation.");
+                            Prelude.unreachable();
                         };
                     };
-                };
-                case (?canister) {
-                    rootBucket := ?Principal.toText(canister);
+
+                    // Retrieve root bucket principal after creation.
+                    switch (await _getRootBucket(tokenContractId)) {
+                        case (?c) {
+                            // Store the new root bucket principal in memory.
+                            rootBucket := ?c;
+                        };
+                        case _ {
+                            // Debug.print("Root bucket cannot be null after root bucket creation.");
+                            Prelude.unreachable();
+                        };
+                    };
                 };
             };
         };

--- a/src/Cap.mo
+++ b/src/Cap.mo
@@ -32,10 +32,10 @@ import Option "mo:base/Option";
 import Prelude "mo:base/Prelude";
 
 module {
-    public class Cap(override_mainnet_router_id: ?Text) {
+    public class Cap(override_mainnet_router_id: ?Text, override_root_bucket_id: ?Text) {
         let router_id = Option.get(override_mainnet_router_id, Router.mainnet_id);
         
-        var rootBucket: ?Text = null;
+        var rootBucket: ?Text = override_root_bucket_id;
         let ic: IC.ICActor = actor("aaaaa-aa");
 
         public func getTransaction(id: Nat64) : async Result.Result<Root.Event, Types.GetTransactionError> {
@@ -67,7 +67,10 @@ module {
         public func insert(event: Root.IndefiniteEvent) : async Result.Result<Nat64, Types.InsertTransactionError> {
             let root = switch(rootBucket) {
                 case(?r) { r };
-                case(_) { Prelude.unreachable() };
+                case(_) {
+                    Debug.print("Trapping: Root bucket was undefined on call to `insert`.");
+                    Prelude.unreachable();
+                };
             };
             let rb: Root.Self = actor(root);
 


### PR DESCRIPTION
- Fixes issue where root bucket for a token contract was being requested using the router canister principal.
- Adds try/catch around cross canister calls to provide more useful error messages.
- Fixes a bad use of `unreachable`.
- camelCase
- Adds some hopefully helpful comments.
- Increases creation cycles in example: 100B was enough to create the canister, but this would lead to a failure when the cap router attempts to install code into the new canister because all of the cycles are consumed in creation. The minimum would appear to be somewhere around 200B, but I set it to 1T based on rckprtr's experience with Cap in rust. 