### PR TITLE
Persist Root History Canister ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ let Package =
 
 let
   additions =
-      [{ name = "base"
+      [{ name = "cap-motoko-library"
       , repo = "https://github.com/Psychedelic/cap-motoko-library"
       , version = "v1.0.0"
       , dependencies = [] : List Text
@@ -84,7 +84,13 @@ let
 
 in  upstream # additions
 ```
-
+Make sure you also add the library as a dependency to your `vessel.dhall` file like this:
+```sh
+{
+  dependencies = [ "base", "cap-motoko-library" ],
+  compiler = Some "0.6.11"
+}
+```
 We've assumed that you have followed `Vessel` initialisation e.g. the init and the `dfx.json`. 
 
 Here's a breakdown of a project initialised by the [dfx cli](https://smartcontracts.org/docs/developers-guide/cli-reference.html):

--- a/examples/README.md
+++ b/examples/README.md
@@ -64,6 +64,7 @@ It should take a bit, and once completed you'll find the output it similar to:
 
 Where `()` is the returned value, if we did NOT get any errors during the process handling!
 
+💡 When following the `cap-motoko-example` code structure in your own project, there is no need to call `init` after canister upgrades as the Root History Canister ID is persisted in stable memory.
 ## 3. Test the History by Making a Call to Insert an Event
 
 From then on we can simple use the remaining methods available, such as `insert`. This means that we do the initialisation only once and NOT everytime we need to make a Cap call.

--- a/examples/insert/dfx.json
+++ b/examples/insert/dfx.json
@@ -11,7 +11,7 @@
       "packtool": "vessel sources"
     }
   },
-  "dfx": "0.8.1",
+  "dfx": "0.8.5",
   "networks": {
     "local": {
       "bind": "127.0.0.1:8000",

--- a/examples/insert/package-set.dhall
+++ b/examples/insert/package-set.dhall
@@ -6,7 +6,7 @@ let
   additions =
       [{ name = "cap"
       , repo = "https://github.com/Psychedelic/cap-motoko-library"
-      , version = "v1.0.3"
+      , version = "v1.0.4"
       , dependencies = [] : List Text
       }] : List Package
 

--- a/examples/insert/src/main.mo
+++ b/examples/insert/src/main.mo
@@ -26,10 +26,17 @@ shared actor class InsertExample (
     // see the releases https://github.com/Psychedelic/cap/tags
     let routerId = Option.get(overrideRouterCanister, Router.mainnet_id);
 
+    // Create a stable variable to persist the Root Canister ID during upgrades.
+    // This way the init() method doesn't need to be called after canister upgrades.
+    private stable var rootBucketId : ?Text = null;
+
     // If the local replica router is not set
     // then the mainnet id is used "lj532-6iaaa-aaaah-qcc7a-cai" 
     // and because the expected argument is an optional we pass as ?xxx
-    let cap = Cap.Cap(?routerId);
+    // We also pass in the rootBucketId. If the init() method has been called before,
+    // the rootBucketId variable contains the principal for this canisters root bucket,
+    // otherwise it's null.
+    let cap = Cap.Cap(?routerId, rootBucketId);
 
     // The number of cycles to use when initialising
     // the handshake process which creates a new canister
@@ -55,7 +62,7 @@ shared actor class InsertExample (
         // but could be declared in the function signature
         // and pass when executing the request
         try {
-            let handshake = await cap.handshake(
+            rootBucketId := await cap.handshake(
                 tokenContractId,
                 creationCycles
             );


### PR DESCRIPTION
## Why?

This way we don't need to call `init` after canister upgrades.
## How?

- add `provideRootBucketId : ?Text` argument to `Cap` class
- let `handshake` return the Root History Canister ID
- in the integrating canister, create a stable variable `rootBucketId : ?Text` and store the result of the `handshake` inside

closes #7 
also includes #6 

## Contribution checklist?

- [x] The commit messages are detailed
- [ ] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [x] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly