### PR TITLE
fix: 🐛 vessel verify fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ let
       [{ name = "cap-motoko-library"
       , repo = "https://github.com/Psychedelic/cap-motoko-library"
       , version = "v1.0.0"
-      , dependencies = [] : List Text
+      , dependencies = ["base"] : List Text
       }] : List Package
 
 in  upstream # additions

--- a/examples/insert/package-set.dhall
+++ b/examples/insert/package-set.dhall
@@ -7,7 +7,7 @@ let
       [{ name = "cap"
       , repo = "https://github.com/Psychedelic/cap-motoko-library"
       , version = "v1.0.4"
-      , dependencies = [] : List Text
+      , dependencies = ["base"] : List Text
       }] : List Package
 
 in  upstream # additions


### PR DESCRIPTION
Added `base` as a dependency in the README for cap.

## Why?

The `base` dependency needs to be added, otherwise `vessel verify` fails with this error message when cap is used in another project:
```
Failed to verify "cap" with:
.vessel/cap/v1.0.4/src/Cap.mo:23.1-23.43: import error [M0010], package "base" not defined
.vessel/cap/v1.0.4/src/Cap.mo:24.1-24.29: import error [M0010], package "base" not defined
.vessel/cap/v1.0.4/src/Cap.mo:25.1-25.29: import error [M0010], package "base" not defined
.vessel/cap/v1.0.4/src/Cap.mo:26.1-26.29: import error [M0010], package "base" not defined
.vessel/cap/v1.0.4/src/Cap.mo:27.1-27.31: import error [M0010], package "base" not defined
.vessel/cap/v1.0.4/src/Cap.mo:28.1-28.33: import error [M0010], package "base" not defined
.vessel/cap/v1.0.4/src/Cap.mo:29.1-29.37: import error [M0010], package "base" not defined
.vessel/cap/v1.0.4/src/Cap.mo:30.1-30.31: import error [M0010], package "base" not defined

Error: Failed to verify: ["cap"]
```
## How?

Changing README

## Contribution checklist?

- [x] The commit messages are detailed
- [x] It does not break existing features (unless required)
- [x] I have performed a self-review of my own code
- [x] Documentation has been updated to reflect the changes
- [ ] Tests have been added or updated to reflect the changes
- [ ] All code formatting pass
- [ ] All lints pass
- [ ] All tests pass

## Security checklist?

- [ ] Injection has been prevented (parameterized queries, no eval or system calls)
- [ ] Sensitive data has been identified and is being protected properly

## Demo?

Optionally, provide any screenshot, gif or small video.
